### PR TITLE
Support local Prithvi checkpoints

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,2 @@
+"""Model packages for FloodScope."""
+

--- a/models/prithvi_transformers/model_loader.py
+++ b/models/prithvi_transformers/model_loader.py
@@ -1,24 +1,64 @@
 # models/prithvi_transformers/model_loader.py
 
-from transformers import AutoModel, AutoProcessor, AutoConfig
+import os
+from pathlib import Path
+
+from transformers import AutoConfig, AutoModel, AutoProcessor
+
+from llm import config as llm_config
+
+
+_MODEL_ID = "ibm-nasa-geospatial/Prithvi-EO-1.0-100M"
+
+
+def _candidate_paths():
+    """Yield candidate local paths for the Prithvi checkpoint."""
+    env_path = os.environ.get("PRITHVI_MODEL_PATH")
+    if env_path:
+        yield Path(env_path).expanduser()
+
+    config_path = getattr(llm_config, "PRITHVI_MODEL_PATH", None)
+    if config_path:
+        yield Path(config_path).expanduser()
+
+
+def _resolve_local_path():
+    """Return the first existing directory that may contain local assets."""
+    for path in _candidate_paths():
+        if path.is_file():
+            path = path.parent
+        if path.is_dir():
+            return str(path)
+    return None
+
 
 def load_prithvi_model():
-    """
-    Loads the IBM-NASA Prithvi Model (Sentinel-2) using Transformers.
-    """
+    """Load the IBM-NASA Prithvi Model (Sentinel-2) using Transformers."""
+
     print("\n🚀 Loading IBM-NASA Prithvi Model (Sentinel-2) using Transformers...")
-    
-    # Directly specify num_labels and label mappings in the config dictionary
-    config = AutoConfig.from_pretrained(
-        "ibm-nasa-geospatial/Prithvi-EO-1.0-100M",
-        num_labels=2,
-        id2label={0: "Non-Flooded", 1: "Flooded"},
-        label2id={"Non-Flooded": 0, "Flooded": 1}
-    )
-    
-    # Load model with config
-    model = AutoModel.from_pretrained("ibm-nasa-geospatial/Prithvi-EO-1.0-100M", config=config)
-    processor = AutoProcessor.from_pretrained("ibm-nasa-geospatial/Prithvi-EO-1.0-100M")
-    
+
+    local_path = _resolve_local_path()
+    model_source = local_path or _MODEL_ID
+
+    try:
+        config = AutoConfig.from_pretrained(
+            model_source,
+            num_labels=2,
+            id2label={0: "Non-Flooded", 1: "Flooded"},
+            label2id={"Non-Flooded": 0, "Flooded": 1},
+        )
+
+        model = AutoModel.from_pretrained(model_source, config=config)
+        processor = AutoProcessor.from_pretrained(model_source)
+    except Exception as exc:
+        location_msg = (
+            f"local path '{local_path}'" if local_path else f"Hugging Face hub id '{_MODEL_ID}'"
+        )
+        raise RuntimeError(
+            "Failed to load the IBM-NASA Prithvi model. "
+            f"Attempted to use {location_msg}. "
+            "Ensure the checkpoint exists locally or that the Hugging Face Hub is accessible."
+        ) from exc
+
     print("✅ IBM-NASA Prithvi Model Loaded Successfully with num_labels = 2 (Binary Classification)")
     return model, processor

--- a/tests/test_prithvi_model_loader.py
+++ b/tests/test_prithvi_model_loader.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.prithvi_transformers import model_loader
+from llm import config as llm_config
+
+
+class TestPrithviModelLoader(unittest.TestCase):
+    def test_loads_from_local_directory_when_available(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"PRITHVI_MODEL_PATH": tmpdir}, clear=False), \
+                    mock.patch.object(llm_config, "PRITHVI_MODEL_PATH", tmpdir), \
+                    mock.patch("models.prithvi_transformers.model_loader.AutoConfig.from_pretrained") as mock_config, \
+                    mock.patch("models.prithvi_transformers.model_loader.AutoModel.from_pretrained") as mock_model, \
+                    mock.patch("models.prithvi_transformers.model_loader.AutoProcessor.from_pretrained") as mock_processor:
+
+                mock_config.return_value = mock.sentinel.config
+
+                mock_model.side_effect = lambda path, *args, **kwargs: self._assert_path_and_return(
+                    path, tmpdir, mock.sentinel.model
+                )
+                mock_processor.side_effect = lambda path, *args, **kwargs: self._assert_path_and_return(
+                    path, tmpdir, mock.sentinel.processor
+                )
+
+                model, processor = model_loader.load_prithvi_model()
+
+                self.assertIs(model, mock.sentinel.model)
+                self.assertIs(processor, mock.sentinel.processor)
+
+                mock_config.assert_called_once()
+                self.assertEqual(mock_config.call_args.args[0], tmpdir)
+
+    def _assert_path_and_return(self, received_path, expected_path, return_value):
+        self.assertEqual(received_path, expected_path)
+        return return_value
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the Prithvi model loader prefer a locally configured checkpoint directory before falling back to the Hugging Face hub and improve its error reporting
- add a regression test that exercises the local loading path without requiring network access
- declare the models directory as a package so tests can import the loader

## Testing
- pytest tests/test_prithvi_model_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68cdfd253a14832982eabc407b43ee33