### PR TITLE
Add evaluation threshold optimisation utilities and tests

### DIFF
--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,16 @@
+"""Utilities for evaluating model comparisons and threshold selection."""
+
+from .experiments import optimise_threshold, summarise_threshold_sweep
+from .data_loader import (
+    ScenePreferenceSummary,
+    compute_scene_preferences,
+    optimise_threshold_from_masks,
+)
+
+__all__ = [
+    "optimise_threshold",
+    "summarise_threshold_sweep",
+    "ScenePreferenceSummary",
+    "compute_scene_preferences",
+    "optimise_threshold_from_masks",
+]

--- a/evaluation/data_loader.py
+++ b/evaluation/data_loader.py
@@ -1,0 +1,189 @@
+"""Helpers for preparing scene-level evaluation signals for threshold optimisation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+
+from .experiments import optimise_threshold
+
+
+@dataclass
+class ScenePreferenceSummary:
+    """Holds scene-level comparison metrics between two models.
+
+    Attributes
+    ----------
+    score_deltas:
+        The per-scene difference between the IoU (or any other quality metric)
+        achieved by model A minus model B. Positive values therefore indicate a
+        preference towards model A.
+    labels:
+        Binary array where 1 denotes that model A achieved a strictly higher
+        IoU than model B for the scene.
+    model_a_iou:
+        IoU scores for model A for each scene.
+    model_b_iou:
+        IoU scores for model B for each scene.
+    scene_ids:
+        Optional identifiers describing the scenes in the same order as the
+        arrays above. When omitted, scenes are implicitly indexed.
+    """
+
+    score_deltas: np.ndarray
+    labels: np.ndarray
+    model_a_iou: np.ndarray
+    model_b_iou: np.ndarray
+    scene_ids: Tuple[str, ...] | None = None
+
+    def as_threshold_inputs(self) -> Tuple[np.ndarray, np.ndarray]:
+        """Return the values expected by :func:`optimise_threshold`.
+
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray]
+            A tuple containing the score deltas and the binary labels.
+        """
+
+        return self.score_deltas, self.labels
+
+
+def _ensure_bool_array(mask: np.ndarray) -> np.ndarray:
+    arr = np.asarray(mask)
+    if arr.dtype != np.bool_:
+        arr = arr.astype(bool)
+    if arr.ndim == 0:
+        raise ValueError("Masks must be at least one-dimensional arrays.")
+    return arr
+
+
+def _compute_iou(ground_truth: np.ndarray, prediction: np.ndarray) -> float:
+    gt = _ensure_bool_array(ground_truth)
+    pred = _ensure_bool_array(prediction)
+    intersection = np.logical_and(gt, pred).sum(dtype=float)
+    union = np.logical_or(gt, pred).sum(dtype=float)
+    if union == 0:
+        # Both masks empty -> perfect IoU, only prediction populated -> zero IoU.
+        return 1.0 if intersection == 0 else 0.0
+    return float(intersection / union)
+
+
+def compute_scene_preferences(
+    ground_truth_masks: Sequence[np.ndarray],
+    model_a_masks: Sequence[np.ndarray],
+    model_b_masks: Sequence[np.ndarray],
+    *,
+    scene_ids: Iterable[str] | None = None,
+    tie_strategy: str = "negative",
+) -> ScenePreferenceSummary:
+    """Compute scene-level IoU comparisons for two competing models.
+
+    Parameters
+    ----------
+    ground_truth_masks:
+        Sequence of ground-truth flood masks.
+    model_a_masks, model_b_masks:
+        Predicted masks for the two models under comparison. The sequences must
+        be aligned with ``ground_truth_masks``.
+    scene_ids:
+        Optional identifiers for each scene. When not provided the scenes are
+        implicitly indexed.
+    tie_strategy:
+        Specifies how to label scenes where both models achieve exactly the same
+        IoU. Accepted values are ``"negative"`` (default, mark as model B
+        winning), ``"positive"`` (mark as model A winning) or ``"skip`` to drop
+        the scene from the results.
+
+    Returns
+    -------
+    ScenePreferenceSummary
+        An object holding the IoU scores, their difference and the resulting
+        binary labels indicating which model performed better.
+    """
+
+    gt_masks = list(ground_truth_masks)
+    model_a = list(model_a_masks)
+    model_b = list(model_b_masks)
+
+    if not (len(gt_masks) == len(model_a) == len(model_b)):
+        raise ValueError("All mask collections must have the same length.")
+
+    if scene_ids is not None:
+        scene_id_list = tuple(scene_ids)
+        if len(scene_id_list) != len(gt_masks):
+            raise ValueError("scene_ids must align with the provided masks.")
+    else:
+        scene_id_list = None
+
+    score_deltas: List[float] = []
+    labels: List[int] = []
+    model_a_iou: List[float] = []
+    model_b_iou: List[float] = []
+    retained_scene_ids: List[str] = []
+
+    for idx, (gt, pred_a, pred_b) in enumerate(zip(gt_masks, model_a, model_b)):
+        iou_a = _compute_iou(gt, pred_a)
+        iou_b = _compute_iou(gt, pred_b)
+        delta = iou_a - iou_b
+
+        if delta > 0:
+            label = 1
+        elif delta < 0:
+            label = 0
+        else:
+            if tie_strategy == "negative":
+                label = 0
+            elif tie_strategy == "positive":
+                label = 1
+            elif tie_strategy == "skip":
+                continue
+            else:
+                raise ValueError(
+                    "tie_strategy must be 'negative', 'positive' or 'skip'."
+                )
+
+        score_deltas.append(delta)
+        labels.append(label)
+        model_a_iou.append(iou_a)
+        model_b_iou.append(iou_b)
+        if scene_id_list is not None:
+            retained_scene_ids.append(scene_id_list[idx])
+
+    summary = ScenePreferenceSummary(
+        score_deltas=np.asarray(score_deltas, dtype=float),
+        labels=np.asarray(labels, dtype=int),
+        model_a_iou=np.asarray(model_a_iou, dtype=float),
+        model_b_iou=np.asarray(model_b_iou, dtype=float),
+        scene_ids=tuple(retained_scene_ids) if scene_id_list is not None else None,
+    )
+    return summary
+
+
+def optimise_threshold_from_masks(
+    ground_truth_masks: Sequence[np.ndarray],
+    model_a_masks: Sequence[np.ndarray],
+    model_b_masks: Sequence[np.ndarray],
+    **optimisation_kwargs,
+):
+    """Convenience wrapper combining :func:`compute_scene_preferences` and
+    :func:`optimise_threshold`.
+
+    Parameters
+    ----------
+    ground_truth_masks, model_a_masks, model_b_masks:
+        See :func:`compute_scene_preferences`.
+    optimisation_kwargs:
+        Additional arguments forwarded to :func:`optimise_threshold` such as the
+        optimisation objective.
+
+    Returns
+    -------
+    ThresholdOptimisationResult
+        The outcome of the threshold optimisation using the per-scene IoU
+        differences as the predictive signal and the computed labels.
+    """
+
+    summary = compute_scene_preferences(ground_truth_masks, model_a_masks, model_b_masks)
+    scores, labels = summary.as_threshold_inputs()
+    return optimise_threshold(scores, labels, **optimisation_kwargs)

--- a/evaluation/experiments.py
+++ b/evaluation/experiments.py
@@ -1,0 +1,237 @@
+"""Threshold sweep helpers for evaluating model preference scores."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import numpy as np
+
+
+@dataclass
+class ThresholdMetrics:
+    """Metrics captured for a single threshold decision."""
+
+    threshold: float
+    true_positives: int
+    false_positives: int
+    true_negatives: int
+    false_negatives: int
+    true_positive_rate: float
+    false_positive_rate: float
+    precision: float
+    recall: float
+    accuracy: float
+    f1_score: float
+
+
+@dataclass
+class ThresholdSweepSummary:
+    """Aggregate metrics computed across a threshold sweep."""
+
+    metrics: List[ThresholdMetrics]
+    roc_fpr: np.ndarray
+    roc_tpr: np.ndarray
+    roc_thresholds: np.ndarray
+    auc: float
+
+
+@dataclass
+class ThresholdOptimisationResult:
+    """Holds the outcome of a threshold optimisation run."""
+
+    summary: ThresholdSweepSummary
+    best_threshold: float
+    criterion: str
+    best_metrics: ThresholdMetrics
+
+
+def _prepare_arrays(
+    scores: Sequence[float],
+    labels: Sequence[int] | Sequence[bool],
+) -> tuple[np.ndarray, np.ndarray]:
+    score_arr = np.asarray(scores, dtype=float)
+    label_arr = np.asarray(labels)
+    if score_arr.ndim != 1 or label_arr.ndim != 1:
+        raise ValueError("scores and labels must be one-dimensional arrays")
+    if score_arr.size != label_arr.size:
+        raise ValueError("scores and labels must have the same length")
+    if score_arr.size == 0:
+        raise ValueError("scores and labels must not be empty")
+    label_arr = label_arr.astype(int)
+    if not np.isin(label_arr, [0, 1]).all():
+        raise ValueError("labels must be binary values (0 or 1)")
+    return score_arr, label_arr
+
+
+def summarise_threshold_sweep(
+    scores: Sequence[float],
+    *,
+    labels: Sequence[int] | Sequence[bool],
+    thresholds: Sequence[float] | None = None,
+) -> ThresholdSweepSummary:
+    """Evaluate classification quality for a set of score thresholds.
+
+    Parameters
+    ----------
+    scores:
+        Per-scene score deltas indicating how strongly model A outperforms model
+        B. Positive values favour model A.
+    labels:
+        Binary indicators containing the *true* outcome for each scene (1 when
+        model A actually achieves the higher IoU, 0 otherwise).
+    thresholds:
+        Optional explicit list of thresholds to evaluate. When omitted, the
+        function will examine all unique score values and include ``-inf`` and
+        ``inf`` to cover degenerate cases.
+    """
+
+    score_arr, label_arr = _prepare_arrays(scores, labels)
+
+    if thresholds is None:
+        unique_thresholds = np.unique(score_arr)
+    else:
+        unique_thresholds = np.asarray(list(thresholds), dtype=float)
+        if unique_thresholds.ndim != 1:
+            raise ValueError("thresholds must be a one-dimensional sequence")
+    sweep_thresholds = np.concatenate(([-np.inf], unique_thresholds, [np.inf]))
+
+    positives = label_arr.sum()
+    negatives = label_arr.size - positives
+
+    metrics: List[ThresholdMetrics] = []
+    for threshold in sweep_thresholds:
+        predictions = score_arr >= threshold
+        tp = int(np.logical_and(predictions, label_arr == 1).sum())
+        fp = int(np.logical_and(predictions, label_arr == 0).sum())
+        tn = int(np.logical_and(~predictions, label_arr == 0).sum())
+        fn = int(np.logical_and(~predictions, label_arr == 1).sum())
+
+        tpr = tp / positives if positives else 0.0
+        fpr = fp / negatives if negatives else 0.0
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tpr
+        accuracy = (tp + tn) / label_arr.size if label_arr.size else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+        metrics.append(
+            ThresholdMetrics(
+                threshold=float(threshold),
+                true_positives=tp,
+                false_positives=fp,
+                true_negatives=tn,
+                false_negatives=fn,
+                true_positive_rate=float(tpr),
+                false_positive_rate=float(fpr),
+                precision=float(precision),
+                recall=float(recall),
+                accuracy=float(accuracy),
+                f1_score=float(f1),
+            )
+        )
+
+    roc_fpr, roc_tpr, roc_thresholds, auc = _compute_roc_auc(label_arr, score_arr)
+
+    return ThresholdSweepSummary(
+        metrics=metrics,
+        roc_fpr=roc_fpr,
+        roc_tpr=roc_tpr,
+        roc_thresholds=roc_thresholds,
+        auc=auc,
+    )
+
+
+def _metric_for_objective(metric: ThresholdMetrics, objective: str) -> float:
+    if objective == "youden":
+        return metric.true_positive_rate - metric.false_positive_rate
+    if objective == "f1":
+        return metric.f1_score
+    if objective == "accuracy":
+        return metric.accuracy
+    raise ValueError(
+        "Unknown objective '%s'. Expected one of {'youden', 'f1', 'accuracy'}."
+        % objective
+    )
+
+
+def optimise_threshold(
+    scores: Sequence[float],
+    labels: Sequence[int] | Sequence[bool],
+    *,
+    thresholds: Sequence[float] | None = None,
+    objective: str = "youden",
+) -> ThresholdOptimisationResult:
+    """Determine the optimal threshold separating model preference outcomes."""
+
+    summary = summarise_threshold_sweep(scores, labels=labels, thresholds=thresholds)
+
+    objective_values = np.array([
+        _metric_for_objective(metric, objective) for metric in summary.metrics
+    ])
+    if np.all(np.isnan(objective_values)):
+        raise ValueError("Objective produced NaN across all thresholds.")
+
+    max_value = np.nanmax(objective_values)
+    candidate_indices = np.flatnonzero(np.isclose(objective_values, max_value, equal_nan=False))
+    if candidate_indices.size == 0:
+        candidate_indices = np.array([int(np.nanargmax(objective_values))])
+
+    def sort_key(idx: int) -> tuple[float, float]:
+        threshold = summary.metrics[idx].threshold
+        return (-objective_values[idx], abs(threshold))
+
+    best_index = int(sorted(candidate_indices, key=sort_key)[0])
+    best_metric = summary.metrics[best_index]
+
+    return ThresholdOptimisationResult(
+        summary=summary,
+        best_threshold=best_metric.threshold,
+        criterion=objective,
+        best_metrics=best_metric,
+    )
+
+
+def _compute_roc_auc(labels: np.ndarray, scores: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    """Compute ROC coordinates and AUC without relying on scikit-learn.
+
+    The implementation mirrors the behaviour of :func:`sklearn.metrics.roc_curve`
+    and :func:`sklearn.metrics.roc_auc_score` but avoids introducing a heavy
+    dependency into the evaluation tooling.
+    """
+
+    labels = labels.astype(int)
+    if labels.ndim != 1 or scores.ndim != 1:
+        raise ValueError("labels and scores must be one-dimensional arrays")
+    if labels.size != scores.size:
+        raise ValueError("labels and scores must be aligned")
+
+    positives = labels.sum()
+    negatives = labels.size - positives
+    if positives == 0 or negatives == 0:
+        # ROC is undefined when only one class is present.
+        return (
+            np.array([0.0, 1.0], dtype=float),
+            np.array([0.0, 1.0], dtype=float),
+            np.array([np.inf, -np.inf], dtype=float),
+            float("nan"),
+        )
+
+    order = np.argsort(scores, kind="mergesort")[::-1]
+    sorted_scores = scores[order]
+    sorted_labels = labels[order]
+
+    distinct_indices = np.where(np.diff(sorted_scores))[0]
+    threshold_idxs = np.r_[distinct_indices, sorted_labels.size - 1]
+
+    tps = np.cumsum(sorted_labels)[threshold_idxs]
+    fps = (1 + threshold_idxs) - tps
+
+    tps = np.r_[0, tps]
+    fps = np.r_[0, fps]
+    thresholds = np.r_[np.inf, sorted_scores[threshold_idxs]]
+
+    tpr = tps / positives
+    fpr = fps / negatives
+
+    auc = float(np.trapezoid(tpr, fpr))
+
+    return fpr, tpr, thresholds, auc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ dependencies = [
     "firebase-admin>=6.8.0",
     "sendgrid>=6.12.3",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_evaluation_thresholds.py
+++ b/tests/test_evaluation_thresholds.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+from evaluation.data_loader import compute_scene_preferences, optimise_threshold_from_masks
+from evaluation.experiments import optimise_threshold
+
+
+def _mask_from_indices(indices, shape=(2, 2)):
+    mask = np.zeros(shape, dtype=bool)
+    if indices:
+        rows, cols = np.unravel_index(indices, shape)
+        mask[rows, cols] = True
+    return mask
+
+
+def _generate_dataset(num_positive: int, num_negative: int):
+    """Create synthetic masks where model A wins ``num_positive`` scenes."""
+
+    gt = _mask_from_indices([0, 1])
+    gt_alt = _mask_from_indices([0, 3])
+
+    gt_masks = []
+    model_a_masks = []
+    model_b_masks = []
+
+    # Scenes where model A clearly outperforms model B
+    for i in range(num_positive):
+        base_gt = gt if i % 2 == 0 else gt_alt
+        model_a = base_gt.copy()
+        worse_pixel = 0 if i % 2 == 0 else 3
+        model_b = _mask_from_indices([worse_pixel])
+        gt_masks.append(base_gt)
+        model_a_masks.append(model_a)
+        model_b_masks.append(model_b)
+
+    # Scenes where model B outperforms model A
+    for i in range(num_negative):
+        base_gt = gt if i % 2 == 0 else gt_alt
+        model_b = base_gt.copy()
+        worse_pixel = 2 if i % 2 == 0 else 1
+        model_a = _mask_from_indices([worse_pixel])
+        gt_masks.append(base_gt)
+        model_a_masks.append(model_a)
+        model_b_masks.append(model_b)
+
+    return gt_masks, model_a_masks, model_b_masks
+
+
+@pytest.mark.parametrize("positive_scenes, negative_scenes", [(5, 3), (3, 5)])
+def test_compute_scene_preferences_label_balance(positive_scenes, negative_scenes):
+    gt_masks, model_a_masks, model_b_masks = _generate_dataset(positive_scenes, negative_scenes)
+    summary = compute_scene_preferences(gt_masks, model_a_masks, model_b_masks)
+
+    assert summary.labels.shape == summary.score_deltas.shape
+    assert summary.labels.sum() == positive_scenes
+    assert np.all(summary.labels[:positive_scenes] == 1)
+    assert np.all(summary.labels[positive_scenes:] == 0)
+
+
+def test_threshold_optimisation_reflects_label_distribution():
+    gt_masks, model_a_masks, model_b_masks = _generate_dataset(6, 2)
+    summary_a = compute_scene_preferences(gt_masks, model_a_masks, model_b_masks)
+
+    # Invert the predictions to simulate model B being better most of the time
+    summary_b = compute_scene_preferences(gt_masks, model_b_masks, model_a_masks)
+
+    # Simulated analyser scores that are identical for both scenarios.
+    analyser_scores = np.linspace(-1.0, 1.0, summary_a.labels.size)
+
+    result_a = optimise_threshold(analyser_scores, summary_a.labels)
+    result_b = optimise_threshold(analyser_scores, summary_b.labels)
+
+    assert summary_a.labels.sum() != summary_b.labels.sum(), "Label distributions should differ"
+    assert result_a.summary.auc < 0.2
+    assert result_b.summary.auc > 0.8
+    assert result_a.best_threshold < result_b.best_threshold
+
+
+def test_pipeline_wrapper_matches_direct_invocation():
+    gt_masks, model_a_masks, model_b_masks = _generate_dataset(4, 4)
+    direct_summary = compute_scene_preferences(gt_masks, model_a_masks, model_b_masks)
+    direct_result = optimise_threshold(direct_summary.score_deltas, direct_summary.labels)
+
+    pipeline_result = optimise_threshold_from_masks(gt_masks, model_a_masks, model_b_masks)
+
+    assert np.isclose(direct_result.best_threshold, pipeline_result.best_threshold)
+    assert pytest.approx(direct_result.summary.auc) == pipeline_result.summary.auc


### PR DESCRIPTION
## Summary
- add an `evaluation` package with reusable helpers for sweeping threshold candidates, computing ROC/AUC without sklearn, and picking the optimal cut-off with explicit scene-level labels
- introduce data-loader utilities to derive scene preference labels from ground-truth and model masks and wire them into the optimisation pipeline
- expand the test suite with synthetic scenarios that demonstrate ROC/AUC and threshold changes as label distributions shift and configure pytest to import the new package

## Testing
- `pytest tests/test_evaluation_thresholds.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbcea2737083299aac6296a7edb4b4