### PR TITLE
Handle cloud coverage failures and add tests

### DIFF
--- a/llm/cloud_coverage.py
+++ b/llm/cloud_coverage.py
@@ -1,8 +1,6 @@
-import rasterio
 import numpy as np
+import rasterio
 
-import rasterio
-import numpy as np
 
 def calculate_cloud_coverage(image_path):
     """
@@ -12,30 +10,26 @@ def calculate_cloud_coverage(image_path):
     Returns:
         float: Estimated cloud coverage ratio (0 to 1).
     """
-    try:
-        with rasterio.open(image_path) as src:
-            # Read bands: B02 (blue), B03 (green), B04 (red), B08 (NIR)
-            blue = src.read(1).astype(float)
-            green = src.read(2).astype(float)
-            red = src.read(3).astype(float)
-            nir = src.read(4).astype(float)
+    with rasterio.open(image_path) as src:
+        # Read bands: B02 (blue), B03 (green), B04 (red), B08 (NIR)
+        blue = src.read(1).astype(float)
+        green = src.read(2).astype(float)
+        red = src.read(3).astype(float)
+        nir = src.read(4).astype(float)
 
-            # Normalize bands to 0-1 range assuming 12-bit data (0-4095)
-            blue /= 4095.0
-            green /= 4095.0
-            red /= 4095.0
-            nir /= 4095.0
+        # Normalize bands to 0-1 range assuming 12-bit data (0-4095)
+        blue /= 4095.0
+        green /= 4095.0
+        red /= 4095.0
+        nir /= 4095.0
 
-            # Simple cloud detection heuristic: high reflectance in visible bands and low NDVI
-            ndvi = (nir - red) / (nir + red + 1e-6)
-            brightness = (blue + green + red) / 3.0
+        # Simple cloud detection heuristic: high reflectance in visible bands and low NDVI
+        ndvi = (nir - red) / (nir + red + 1e-6)
+        brightness = (blue + green + red) / 3.0
 
-            cloud_mask = (brightness > 0.3) & (ndvi < 0.1)
+        cloud_mask = (brightness > 0.3) & (ndvi < 0.1)
 
-            cloud_pixels = np.sum(cloud_mask)
-            total_pixels = cloud_mask.size
-            cloud_coverage = cloud_pixels / total_pixels
-            return cloud_coverage
-    except Exception as e:
-        print(f"Error calculating cloud coverage: {e}")
-        return 0.0
+        cloud_pixels = np.sum(cloud_mask)
+        total_pixels = cloud_mask.size
+        cloud_coverage = cloud_pixels / total_pixels
+        return cloud_coverage

--- a/llm/main_backend.py
+++ b/llm/main_backend.py
@@ -1,15 +1,123 @@
-from data_fetcher import fetch_image
-from preprocess import preprocess_image
-from model_inference import run_flood_detection as run_prithvi_inference
-from ai4g_inference import run_ai4g_sar_inference
+import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from geopy.geocoders import Nominatim
+from typing import Callable, List, Optional
 
-def check_cloud_coverage(image_path):
-    # Placeholder function to check cloud coverage in Sentinel-2 image
-    # Returns True if cloud coverage is low enough, False otherwise
-    # Implement actual cloud detection logic here
-    return True
+from ai4g_inference import run_ai4g_sar_inference
+from cloud_coverage import calculate_cloud_coverage
+from data_fetcher import fetch_image
+from model_inference import run_flood_detection as run_prithvi_inference
+from geopy.geocoders import Nominatim
+from preprocess import preprocess_image
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_CLOUD_THRESHOLD = 0.3
+
+
+@dataclass
+class CloudCoverageStatus:
+    """Outcome of a cloud coverage measurement."""
+
+    coverage: Optional[float]
+    is_clear: Optional[bool]
+    error: Optional[str] = None
+
+
+@dataclass
+class OpticalPreparationResult:
+    """Summary of preparing Sentinel-2 imagery for inference."""
+
+    use_sentinel1: bool
+    preprocessed_images: List[str]
+    fallback_reason: Optional[str] = None
+    fallback_date: Optional[str] = None
+    fallback_coverage: Optional[float] = None
+
+
+def check_cloud_coverage(image_path: str, threshold: float = DEFAULT_CLOUD_THRESHOLD) -> CloudCoverageStatus:
+    """Evaluate cloud coverage for a Sentinel-2 scene.
+
+    Args:
+        image_path: Path to the downloaded Sentinel-2 image.
+        threshold: Maximum acceptable cloud coverage ratio.
+
+    Returns:
+        CloudCoverageStatus describing the measurement outcome.
+    """
+
+    try:
+        coverage = calculate_cloud_coverage(image_path)
+    except Exception as exc:  # pragma: no cover - exception path validated via unit tests
+        logger.exception("Unable to determine cloud coverage for %s", image_path)
+        return CloudCoverageStatus(coverage=None, is_clear=None, error=str(exc))
+
+    if coverage is None:
+        message = "Cloud coverage calculation returned no value"
+        logger.error("%s for %s", message, image_path)
+        return CloudCoverageStatus(coverage=None, is_clear=None, error=message)
+
+    is_clear = coverage <= threshold
+    logger.debug(
+        "Calculated cloud coverage %.2f%% for %s (threshold %.2f%%)",
+        coverage * 100,
+        image_path,
+        threshold * 100,
+    )
+    return CloudCoverageStatus(coverage=coverage, is_clear=is_clear)
+
+
+def prepare_optical_imagery(
+    lat: float,
+    lon: float,
+    base_date: datetime,
+    *,
+    fetch_fn: Callable[[float, float, str, str], str] = fetch_image,
+    preprocess_fn: Callable[[str, str], str] = preprocess_image,
+    coverage_fn: Callable[[str], CloudCoverageStatus] = check_cloud_coverage,
+) -> OpticalPreparationResult:
+    """Fetch and preprocess Sentinel-2 imagery, reporting if radar fallback is required."""
+
+    dates = [(base_date - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(2, -1, -1)]
+    preprocessed_images: List[str] = []
+
+    for date in dates:
+        raw_image = fetch_fn(lat, lon, date, sensor="Sentinel-2")
+        status = coverage_fn(raw_image)
+
+        if status.error:
+            logger.warning(
+                "Falling back to Sentinel-1 because cloud coverage could not be assessed for %s: %s",
+                date,
+                status.error,
+            )
+            return OpticalPreparationResult(
+                use_sentinel1=True,
+                preprocessed_images=[],
+                fallback_reason=status.error,
+                fallback_date=date,
+            )
+
+        if not status.is_clear:
+            logger.info(
+                "Falling back to Sentinel-1 due to %.2f%% cloud coverage on %s",
+                status.coverage * 100 if status.coverage is not None else float("nan"),
+                date,
+            )
+            return OpticalPreparationResult(
+                use_sentinel1=True,
+                preprocessed_images=[],
+                fallback_reason="high cloud coverage",
+                fallback_date=date,
+                fallback_coverage=status.coverage,
+            )
+
+        processed_image = preprocess_fn(raw_image, date_str=date)
+        preprocessed_images.append(processed_image)
+
+    return OpticalPreparationResult(use_sentinel1=False, preprocessed_images=preprocessed_images)
 
 def main():
     print("\\n🌐 Flood Detection System - Prithvi and AI4G Models (Sentinel-2 and Sentinel-1)\\n")
@@ -51,15 +159,17 @@ def main():
 
     if sensor_choice == '2':
         # Sentinel-2 only
-        dates = [(base_date - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(2, -1, -1)]
-        preprocessed_images = []
-        for date in dates:
-            raw_image = fetch_image(lat, lon, date, sensor="Sentinel-2")
-            if not check_cloud_coverage(raw_image):
-                print(f"☁️ High cloud coverage detected on {date}. Consider using Sentinel-1.")
-            processed_image = preprocess_image(raw_image, date_str=date)
-            preprocessed_images.append(processed_image)
-        run_prithvi_inference(preprocessed_images)
+        optical_result = prepare_optical_imagery(lat, lon, base_date)
+        if optical_result.use_sentinel1:
+            print(
+                "⚠️ Unable to obtain reliable cloud coverage for Sentinel-2 on {}. "
+                "Please rerun with Sentinel-1 (SAR) for guaranteed observations.".format(
+                    optical_result.fallback_date or base_date.strftime("%Y-%m-%d")
+                )
+            )
+            return
+
+        run_prithvi_inference(optical_result.preprocessed_images)
 
     elif sensor_choice == '3':
         # Sentinel-1 only
@@ -72,19 +182,24 @@ def main():
         run_ai4g_sar_inference(pre_vv, pre_vh, post_vv, post_vh)
 
     else:
-        # Automatic: try Sentinel-2 first, fallback to Sentinel-1 if cloudy
-        dates = [(base_date - timedelta(days=i)).strftime("%Y-%m-%d") for i in range(2, -1, -1)]
-        preprocessed_images = []
-        use_sentinel1 = False
-        for date in dates:
-            raw_image = fetch_image(lat, lon, date, sensor="Sentinel-2")
-            if not check_cloud_coverage(raw_image):
-                use_sentinel1 = True
-                break
-            processed_image = preprocess_image(raw_image, date_str=date)
-            preprocessed_images.append(processed_image)
-        if use_sentinel1:
-            print("☁️ Cloud coverage too high for Sentinel-2. Switching to Sentinel-1 SAR model.")
+        # Automatic: try Sentinel-2 first, fallback to Sentinel-1 if cloudy or uncertain
+        optical_result = prepare_optical_imagery(lat, lon, base_date)
+        if optical_result.use_sentinel1:
+            if optical_result.fallback_reason:
+                print(
+                    "☁️ Switching to Sentinel-1 SAR model because Sentinel-2 imagery on {date} "
+                    "was unavailable or too cloudy ({reason}).".format(
+                        date=optical_result.fallback_date or base_date.strftime("%Y-%m-%d"),
+                        reason=(
+                            f"{optical_result.fallback_coverage * 100:.1f}% cloud cover"
+                            if optical_result.fallback_coverage is not None
+                            else optical_result.fallback_reason
+                        ),
+                    )
+                )
+            else:
+                print("☁️ Cloud coverage too high for Sentinel-2. Switching to Sentinel-1 SAR model.")
+
             pre_date = (base_date - timedelta(days=1)).strftime("%Y-%m-%d")
             post_date = base_date.strftime("%Y-%m-%d")
             pre_vv = fetch_image(lat, lon, pre_date, sensor="Sentinel-1")
@@ -93,7 +208,7 @@ def main():
             post_vh = fetch_image(lat, lon, post_date, sensor="Sentinel-1")
             run_ai4g_sar_inference(pre_vv, pre_vh, post_vv, post_vh)
         else:
-            run_prithvi_inference(preprocessed_images)
+            run_prithvi_inference(optical_result.preprocessed_images)
 
     print("\\n✅ Complete Workflow Done!")
 

--- a/tests/test_cloud_coverage_handling.py
+++ b/tests/test_cloud_coverage_handling.py
@@ -1,0 +1,134 @@
+import logging
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.errors import RasterioIOError
+import types
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+LLM_ROOT = PROJECT_ROOT / "llm"
+if str(LLM_ROOT) not in sys.path:
+    sys.path.insert(0, str(LLM_ROOT))
+
+from llm import cloud_coverage
+
+# Provide lightweight stand-ins for heavy runtime dependencies expected by main_backend.
+stub_ai4g = types.ModuleType("ai4g_inference")
+stub_ai4g.run_ai4g_sar_inference = lambda *args, **kwargs: None
+sys.modules.setdefault("ai4g_inference", stub_ai4g)
+
+stub_data_fetcher = types.ModuleType("data_fetcher")
+stub_data_fetcher.fetch_image = lambda *args, **kwargs: ""
+sys.modules.setdefault("data_fetcher", stub_data_fetcher)
+
+stub_model_inference = types.ModuleType("model_inference")
+stub_model_inference.run_flood_detection = lambda *args, **kwargs: None
+sys.modules.setdefault("model_inference", stub_model_inference)
+
+stub_preprocess = types.ModuleType("preprocess")
+stub_preprocess.preprocess_image = lambda *args, **kwargs: ""
+sys.modules.setdefault("preprocess", stub_preprocess)
+
+stub_geopy = types.ModuleType("geopy")
+stub_geopy_geocoders = types.ModuleType("geopy.geocoders")
+
+
+class _StubNominatim:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def geocode(self, *args, **kwargs):  # pragma: no cover - not used in tests
+        return None
+
+
+stub_geopy_geocoders.Nominatim = _StubNominatim
+stub_geopy.geocoders = stub_geopy_geocoders
+sys.modules.setdefault("geopy", stub_geopy)
+sys.modules.setdefault("geopy.geocoders", stub_geopy_geocoders)
+
+from llm import main_backend
+
+
+def write_tiff(path: Path, band_count: int, value: int = 1000) -> None:
+    data = np.full((1, 1), value, dtype=np.uint16)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=1,
+        height=1,
+        count=band_count,
+        dtype=data.dtype,
+    ) as dst:
+        for band in range(1, band_count + 1):
+            dst.write(data, band)
+
+
+def test_calculate_cloud_coverage_missing_band_raises(tmp_path):
+    image_path = tmp_path / "partial_bands.tif"
+    write_tiff(image_path, band_count=2)
+
+    with pytest.raises(IndexError):
+        cloud_coverage.calculate_cloud_coverage(str(image_path))
+
+
+def test_calculate_cloud_coverage_missing_file_raises(tmp_path):
+    missing_path = tmp_path / "does_not_exist.tif"
+
+    with pytest.raises(RasterioIOError):
+        cloud_coverage.calculate_cloud_coverage(str(missing_path))
+
+
+def test_check_cloud_coverage_reports_failure(monkeypatch, caplog):
+    def boom(path):
+        raise RuntimeError("band data unavailable")
+
+    monkeypatch.setattr(main_backend, "calculate_cloud_coverage", boom)
+    caplog.set_level(logging.ERROR)
+
+    status = main_backend.check_cloud_coverage("/tmp/fake.tif")
+
+    assert status.error == "band data unavailable"
+    assert status.coverage is None
+    assert status.is_clear is None
+    assert "Unable to determine cloud coverage" in caplog.text
+
+
+def test_prepare_optical_imagery_switches_to_radar_on_failure(tmp_path):
+    base_date = datetime(2024, 1, 3)
+
+    fetched_paths = []
+
+    def fake_fetch(lat, lon, date, sensor="Sentinel-2"):
+        fetched_paths.append((sensor, date))
+        image_path = tmp_path / f"{sensor}_{date}.tif"
+        write_tiff(image_path, band_count=4)
+        return str(image_path)
+
+    def fake_preprocess(path, date_str):
+        return f"processed_{date_str}"
+
+    def failing_coverage(path):
+        return main_backend.CloudCoverageStatus(coverage=None, is_clear=None, error="quality check failed")
+
+    result = main_backend.prepare_optical_imagery(
+        12.0,
+        77.0,
+        base_date,
+        fetch_fn=fake_fetch,
+        preprocess_fn=fake_preprocess,
+        coverage_fn=failing_coverage,
+    )
+
+    assert result.use_sentinel1 is True
+    assert result.preprocessed_images == []
+    assert result.fallback_reason == "quality check failed"
+    assert result.fallback_date == (base_date - timedelta(days=2)).strftime("%Y-%m-%d")
+    assert fetched_paths == [("Sentinel-2", (base_date - timedelta(days=2)).strftime("%Y-%m-%d"))]


### PR DESCRIPTION
## Summary
- allow `calculate_cloud_coverage` to surface read errors instead of forcing 0% estimates
- add explicit cloud coverage handling in `main_backend` with logging and radar fallback helper
- cover failure cases and automatic switching logic with new targeted pytest module

## Testing
- `pytest tests/test_cloud_coverage_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_68cbcea09fe083298aa5fed03d534db1